### PR TITLE
Remove "InitialRotationPreference"

### DIFF
--- a/MyerSplash/Package.appxmanifest
+++ b/MyerSplash/Package.appxmanifest
@@ -24,9 +24,6 @@
           </uap:ShowNameOnTiles>
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" BackgroundColor="#070707" />
-        <uap:InitialRotationPreference>
-          <uap:Rotation Preference="portrait" />
-        </uap:InitialRotationPreference>
       </uap:VisualElements>
       <Extensions>
         <Extension Category="windows.backgroundTasks" EntryPoint="BackgroundTask.WallpaperAutoChangeTask">


### PR DESCRIPTION
UWP的一个坑：在未接键盘、处于平板模式、屏幕方向可以自由旋转的 Windows 平板上，如果 InitialRotationPreference 被设为 Portrait，那么在应用启动时屏幕方向会先变为竖直（或者别的什么奇怪的方向），然后再变回原来的方向（比如横向），导致应用启动时屏幕方向换来换去非常不好看。不设置 InitialRotationPreference 没有这个问题。
而且既然 MyerSplash 已不支持 Windows 10 Mobile，感觉这一行也没有必要了。

/*
            避免这个坑的方式是不设 InitialRotationPreference，而是在应用启动时用代码手动锁定旋转：

```
if (Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")  
{  
    DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait; //手机上锁定竖屏  
}  
```
*/