### PR TITLE
Fix networking in private network environment

### DIFF
--- a/MyerSplash/Package.appxmanifest
+++ b/MyerSplash/Package.appxmanifest
@@ -36,6 +36,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer"/>
     <uap:Capability Name="picturesLibrary" />
     <uap:Capability Name="removableStorage" />
   </Capabilities>


### PR DESCRIPTION
If privateNetworkClientServer is not specified, UWP won't have internet access in a private network environment (such as private VPN).